### PR TITLE
Add commands to generate random Namada addresses

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,8 @@
 use namada::types::address::{Address, EstablishedAddressGen};
 use rand::Rng;
 
+use crate::keys::random_keypair;
+
 pub fn generate_established() -> Address {
     let mut rng = rand::thread_rng();
     let seed: [u8; 32] = rng.gen();
@@ -10,4 +12,9 @@ pub fn generate_established() -> Address {
 
     let entropy: [u8; 32] = rng.gen();
     generator.generate_address(entropy)
+}
+
+pub fn generate_implicit() -> Address {
+    let (_secret_key, public_key) = random_keypair();
+    (&public_key).into()
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,7 +1,7 @@
 use namada::types::address::{Address, EstablishedAddressGen};
 use rand::Rng;
 
-pub fn generate_random() -> Address {
+pub fn generate_established() -> Address {
     let mut rng = rand::thread_rng();
     let seed: [u8; 32] = rng.gen();
     let seed = String::from_utf8_lossy(&seed);

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,0 +1,13 @@
+use namada::types::address::{Address, EstablishedAddressGen};
+use rand::Rng;
+
+pub fn generate_random() -> Address {
+    let mut rng = rand::thread_rng();
+    let seed: [u8; 32] = rng.gen();
+    let seed = String::from_utf8_lossy(&seed);
+
+    let mut generator = EstablishedAddressGen::new(&seed);
+
+    let entropy: [u8; 32] = rng.gen();
+    generator.generate_address(entropy)
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -32,6 +32,8 @@ pub(crate) enum Commands {
     PrintRandomKey,
     #[clap(about = "Generate a random established address and print the bech32m to stdout")]
     GenerateEstablishedAddress,
+    #[clap(about = "Generate a random implicit address and print the bech32m to stdout")]
+    GenerateImplicitAddress,
     #[clap(about = "Submit a fake transfer to Namada")]
     SubmitFakeTransferToNamada(FakeTransferToNamada),
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,6 +30,8 @@ pub(crate) enum Commands {
     },
     #[clap(about = "Generate a random secret key and print the Borsh serialization")]
     PrintRandomKey,
+    #[clap(about = "Generate a random Namada bech32m address and print it to stdout")]
+    PrintRandomAddress,
     #[clap(about = "Submit a fake transfer to Namada")]
     SubmitFakeTransferToNamada(FakeTransferToNamada),
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,8 +30,8 @@ pub(crate) enum Commands {
     },
     #[clap(about = "Generate a random secret key and print the Borsh serialization")]
     PrintRandomKey,
-    #[clap(about = "Generate a random Namada bech32m address and print it to stdout")]
-    PrintRandomAddress,
+    #[clap(about = "Generate a random established address and print the bech32m to stdout")]
+    GenerateEstablishedAddress,
     #[clap(about = "Submit a fake transfer to Namada")]
     SubmitFakeTransferToNamada(FakeTransferToNamada),
 }

--- a/src/devtool.rs
+++ b/src/devtool.rs
@@ -76,6 +76,10 @@ pub(crate) async fn run(cmd: args::Commands) -> Result<()> {
             let addr = crate::address::generate_established();
             print!("{}", addr);
         }
+        args::Commands::GenerateImplicitAddress => {
+            let addr = crate::address::generate_implicit();
+            print!("{}", addr);
+        }
     }
     Ok(())
 }

--- a/src/devtool.rs
+++ b/src/devtool.rs
@@ -72,8 +72,8 @@ pub(crate) async fn run(cmd: args::Commands) -> Result<()> {
         args::Commands::SubmitFakeTransferToNamada(fake_transfer_to_namada) => {
             send_fake_transfer_to_namada(fake_transfer_to_namada).await?;
         }
-        args::Commands::PrintRandomAddress => {
-            let addr = crate::address::generate_random();
+        args::Commands::GenerateEstablishedAddress => {
+            let addr = crate::address::generate_established();
             print!("{}", addr);
         }
     }

--- a/src/devtool.rs
+++ b/src/devtool.rs
@@ -72,6 +72,10 @@ pub(crate) async fn run(cmd: args::Commands) -> Result<()> {
         args::Commands::SubmitFakeTransferToNamada(fake_transfer_to_namada) => {
             send_fake_transfer_to_namada(fake_transfer_to_namada).await?;
         }
+        args::Commands::PrintRandomAddress => {
+            let addr = crate::address::generate_random();
+            print!("{}", addr);
+        }
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod address;
 mod args;
 mod devtool;
 mod eth_bridge;


### PR DESCRIPTION
Useful for generating non-existent addresses to be added to a wallet via `namadaw address add` in tests.